### PR TITLE
Fix/rollback changeset 4

### DIFF
--- a/changeset/0004-alter-table-tr_traveller.sql
+++ b/changeset/0004-alter-table-tr_traveller.sql
@@ -1,3 +1,10 @@
+--liquibase formatted sql
+
+--changeset devi:0004 label:v1.0.2 
+
+--comment: postgresql
+
+
 ALTER TABLE public.tr_traveller ADD COLUMN release_date date NULL;
 ALTER TABLE public.tr_traveller ADD COLUMN job varchar(20) NULL;
 

--- a/changeset/0004-alter-table-tr_traveller.sql
+++ b/changeset/0004-alter-table-tr_traveller.sql
@@ -1,2 +1,5 @@
 ALTER TABLE public.tr_traveller ADD COLUMN release_date date NULL;
 ALTER TABLE public.tr_traveller ADD COLUMN job varchar(20) NULL;
+
+--rollback ALTER TABLE public.tr_traveller DROP COLUMN release_date;
+--rollback ALTER TABLE public.tr_traveller DROP COLUMN job;


### PR DESCRIPTION
Rollback attempt to tag 1.0.0 failed because of improper changeset (lack of rollback query, liquibase format sql comment)